### PR TITLE
default to confidential code

### DIFF
--- a/A_General/02_Terms.md
+++ b/A_General/02_Terms.md
@@ -13,8 +13,9 @@ The following definitions are used here:
 | **Critical Application** | Here: Business critical application |
 | **Dependency Repository** | System that manages 3rd party dependencies (e.g. libraries, Maven artifacts). A dependency repository is often part of a general software repository system such as Nexus or Artifactory. |
 | **External Application** | A web-based application that is accessible from the outside of the organization (e.g. via the Internet). |
+| **Internal Code** | Source or program code which is not confidential and not public (standard). For example build code. |
 | **Internal Application** | A web-based application that is only accessible from the inside of the organization (e.g. intranet application). |
-| **Code** | Source or program code that is or is intentend to be deployed in production, often containing confidential information such or sensitive business logic) |
+| **Sensitive Code** | Source or program code that is or is intentend to be deployed in production, containing confidential information such or sensitive business logic) |
 | **Service** | Here: Synonym for (business) application that can contain one or more ->APIs |
 | **Source Code Repository** | System where custom code is stored (e.g. Git). |
 | **Web Application** | Here: A software program (UI, service or API or combination of them) that is accessible via HTTP(s) protocol and fulfills a particular business case. |

--- a/A_General/02_Terms.md
+++ b/A_General/02_Terms.md
@@ -13,9 +13,8 @@ The following definitions are used here:
 | **Critical Application** | Here: Business critical application |
 | **Dependency Repository** | System that manages 3rd party dependencies (e.g. libraries, Maven artifacts). A dependency repository is often part of a general software repository system such as Nexus or Artifactory. |
 | **External Application** | A web-based application that is accessible from the outside of the organization (e.g. via the Internet). |
-| **Internal Code** | Source or program code which is not confidential and not public (standard). |
 | **Internal Application** | A web-based application that is only accessible from the inside of the organization (e.g. intranet application). |
-| **Sensitive Code** | Source or program code that is or is intentend to be deployed in production, containing confidential information such or sensitive business logic) |
+| **Code** | Source or program code that is or is intentend to be deployed in production, often containing confidential information such or sensitive business logic) |
 | **Service** | Here: Synonym for (business) application that can contain one or more ->APIs |
 | **Source Code Repository** | System where custom code is stored (e.g. Git). |
 | **Web Application** | Here: A software program (UI, service or API or combination of them) that is accessible via HTTP(s) protocol and fulfills a particular business case. |


### PR DESCRIPTION
The distinction of confidential and internal code is confusing and not used in TSS-Web. 

I recommend to only have it confidential. "Internal Code" is only referenced once.